### PR TITLE
Allows to declare annotated TypeHandlers

### DIFF
--- a/src/main/java/org/joda/time/mybatis/handlers/DateTimeTypeHandler.java
+++ b/src/main/java/org/joda/time/mybatis/handlers/DateTimeTypeHandler.java
@@ -1,16 +1,14 @@
 package org.joda.time.mybatis.handlers;
 
-import java.sql.CallableStatement;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-
 import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
 import org.apache.ibatis.type.TypeHandler;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.sql.*;
+
+@MappedTypes(DateTime.class)
 public class DateTimeTypeHandler implements TypeHandler
 {
 

--- a/src/main/java/org/joda/time/mybatis/handlers/LocalDateTypeHandler.java
+++ b/src/main/java/org/joda/time/mybatis/handlers/LocalDateTypeHandler.java
@@ -1,16 +1,14 @@
 package org.joda.time.mybatis.handlers;
 
-import java.sql.CallableStatement;
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
 import org.apache.ibatis.type.TypeHandler;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
+import java.sql.*;
+
+@MappedTypes(LocalDate.class)
 public class LocalDateTypeHandler implements TypeHandler
 {
 

--- a/src/main/java/org/joda/time/mybatis/handlers/LocalTimeTypeHandler.java
+++ b/src/main/java/org/joda/time/mybatis/handlers/LocalTimeTypeHandler.java
@@ -1,16 +1,14 @@
 package org.joda.time.mybatis.handlers;
 
-import java.sql.CallableStatement;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Time;
-
 import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
 import org.apache.ibatis.type.TypeHandler;
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
 
+import java.sql.*;
+
+@MappedTypes(LocalTime.class)
 public class LocalTimeTypeHandler implements TypeHandler
 {
 


### PR DESCRIPTION
This pull request allows to declare annotated typehandlers.

For example, in spring configuration, we can use them simply by doing this : https://gist.github.com/1722519
